### PR TITLE
Update config.py

### DIFF
--- a/gigapath/torchscale/architecture/config.py
+++ b/gigapath/torchscale/architecture/config.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Microsoft
 # Licensed under The MIT License [see LICENSE for details]
-
+import numpy as np      # needed for "eval()" on line 71 ....
 
 class EncoderConfig(object):
     def __init__(self, **kwargs):


### PR DESCRIPTION
The "eval()" statement on line71 appears to be evaluating numpy types passed in, as a string?

```
segment_length:  [np.int64(1024), np.int64(5792), np.int64(32768), np.int64(185363), np.int64(1048576)]
```

Possible security issue. Beyond that however, since there is no "np" defined in the scope of this file, initialization fails and the code doesn't run.

```
Traceback (most recent call last):
  File "/gstore/home/mielkec/molecular-subtyping/src/embed/gigapath_embed_slides.py", line 44, in <module>
    slide_encoder_model = slide_encoder.create_model("hf_hub:prov-gigapath/prov-gigapath", "gigapath_slide_enc12l768d", 1536)
  File "/gstore/home/mielkec/molecular-subtyping/src/embed/gigapath/slide_encoder.py", line 228, in create_model
    model = timm.create_model(model_arch, pretrained=False, in_chans=in_chans, **kwargs)
  File "/gstore/home/mielkec/miniforge3/lib/python3.10/site-packages/timm/models/_factory.py", line 117, in create_model
    model = create_fn(
  File "/gstore/home/mielkec/molecular-subtyping/src/embed/gigapath/slide_encoder.py", line 258, in gigapath_slide_enc12l768d
    model = LongNetViT(embed_dim=768, depth=12, mlp_ratio=4, norm_layer=partial(nn.LayerNorm, eps=1e-6), **kwargs)
  File "/gstore/home/mielkec/molecular-subtyping/src/embed/gigapath/slide_encoder.py", line 113, in __init__
    self.encoder = make_longnet_from_name(self.encoder_name, drop_path_rate=drop_path_rate, dropout=dropout, segment_length=segment_length)
  File "/gstore/home/mielkec/molecular-subtyping/src/embed/gigapath/torchscale/model/LongNet.py", line 125, in make_longnet_from_name
    longnet_args = EncoderConfig(**longnet_args)
  File "/gstore/home/mielkec/molecular-subtyping/src/embed/gigapath/torchscale/model/../../torchscale/architecture/config.py", line 61, in __init__
    self.postprocessing()
  File "/gstore/home/mielkec/molecular-subtyping/src/embed/gigapath/torchscale/model/../../torchscale/architecture/config.py", line 71, in postprocessing
    self.segment_length = eval(self.segment_length)
  File "<string>", line 1, in <module>
NameError: name 'np' is not defined

```